### PR TITLE
Use stricter regex for matching URLs when linkifying

### DIFF
--- a/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
+++ b/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
@@ -14402,8 +14402,12 @@ class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
         }
 
         // there is/are URL(s). Let's split the string:
-        // Note: this regex is extremely permissive
-        $bits = preg_split('#((?:https?|ftp)://[^\s\'"<>()]+)#S', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
+        // Note: this regex is extremely permissive (NOT ANYMORE)
+        $bits = preg_split('/((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]'
+                                   .'{2,4}\/)(?:[^\s\(\)\<\>]+|\(([^\s\(\)\<\>]+|(\(['
+                                   .'^\s\(\)\<\>]+\)))*\))+(?:\(([^\s\(\)\<\>]+|(\([^'
+                                   .'\s\(\)\<\>]+\)))*\)|[^\s\`\!\[\]\(\)\{\}\;\:\'\"'
+                                   .'\.\,\<\>\?\&\@\$\%\^\*\-\+\=\\\|\~]))/', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $token = array();
 


### PR DESCRIPTION
Regex used when linkifying previously included punctuation at the end of a URL, causing the link to be broken. This branch adds a stricter regex to exclude those characters and just grab the URL.

Needs to be merged in conjunction with pull 1207 in the app repo
